### PR TITLE
Fix: broken links in docs/guide/why.md

### DIFF
--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -18,7 +18,7 @@ Vite improves the dev server start time by first dividing the modules in an appl
 
 - **Dependencies** are mostly plain JavaScript that do not change often during development. Some large dependencies (e.g. component libraries with hundreds of modules) are also quite expensive to process. Dependencies may also be shipped in various module formats (e.g. ESM or CommonJS).
 
-  Vite [pre-bundles dependencies](./dep-pre-bundling) using [esbuild](https://esbuild.github.io/). esbuild is written in Go and pre-bundles dependencies 10-100x faster than JavaScript-based bundlers.
+  Vite [pre-bundles dependencies](./dep-pre-bundling.md) using [esbuild](https://esbuild.github.io/). esbuild is written in Go and pre-bundles dependencies 10-100x faster than JavaScript-based bundlers.
 
 - **Source code** often contains non-plain JavaScript that needs transforming (e.g. JSX, CSS or Vue/Svelte components), and will be edited very often. Also, not all source code needs to be loaded at the same time (e.g. with route-based code-splitting).
 
@@ -47,7 +47,7 @@ Once you experience how fast Vite is, we highly doubt you'd be willing to put up
 
 Even though native ESM is now widely supported, shipping unbundled ESM in production is still inefficient (even with HTTP/2) due to the additional network round trips caused by nested imports. To get the optimal loading performance in production, it is still better to bundle your code with tree-shaking, lazy-loading and common chunk splitting (for better caching).
 
-Ensuring optimal output and behavioral consistency between the dev server and the production build isn't easy. This is why Vite ships with a pre-configured [build command](./build) that bakes in many [performance optimizations](./features#build-optimizations) out of the box.
+Ensuring optimal output and behavioral consistency between the dev server and the production build isn't easy. This is why Vite ships with a pre-configured [build command](./build.md) that bakes in many [performance optimizations](./features.md#build-optimizations) out of the box.
 
 ## Why Not Bundle with esbuild?
 
@@ -57,4 +57,4 @@ Rollup has also been working on performance improvements, [switching its parser 
 
 ## How is Vite Different from X?
 
-You can check out the [Comparisons](./comparisons) section for more details on how Vite differs from other similar tools.
+You can check out the [Comparisons](./comparisons.md) section for more details on how Vite differs from other similar tools.


### PR DESCRIPTION
### Description

- Fixed broken links in why.md that were resulting in "page not found" errors when clicked on github.
![image](https://github.com/user-attachments/assets/eeea1b29-154e-409f-a2b1-5166e7628b78)




